### PR TITLE
Apply Discord-inspired dark styling to existing layout

### DIFF
--- a/app.css
+++ b/app.css
@@ -12,6 +12,28 @@
 ------------------*/
 @import url("https://fonts.googleapis.com/css?family=Titillium+Web:400,900&display=swap");
 @import url("https://fonts.googleapis.com/css?family=Rajdhani:400,500,600,700&display=swap");
+
+:root {
+  color-scheme: dark;
+  --font-primary: "gg sans", "Noto Sans", "Helvetica Neue", sans-serif;
+  --font-accent: "Rajdhani", sans-serif;
+  --bg-base: #1e1f22;
+  --bg-elevated: #2b2d31;
+  --bg-floating: #313338;
+  --surface-border: rgba(78, 80, 88, 0.65);
+  --surface-border-subtle: rgba(78, 80, 88, 0.35);
+  --text-primary: #f2f3f5;
+  --text-muted: #b5bac1;
+  --text-link: #99a7ff;
+  --text-link-hover: #b3bcff;
+  --interactive-muted: #3f4147;
+  --interactive-hover: rgba(255, 255, 255, 0.06);
+  --interactive-active: rgba(255, 255, 255, 0.12);
+  --accent: #5865f2;
+  --accent-hover: #4752c4;
+  --accent-active: #3c45a5;
+  --shadow-elevated: 0 8px 24px rgba(0, 0, 0, 0.32);
+}
 *,
 *::before,
 *::after {
@@ -1938,32 +1960,40 @@ textarea::placeholder {
     1. GENERAL
 -----------------*/
 *::selection {
-  color: #fff;
-  background-color: #40d04f;
+  color: var(--text-primary);
+  background-color: var(--accent);
 }
 
 body {
   font-size: 16px;
-  background-color: #ffffff;
-  color: #212529;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-primary);
   overflow-x: hidden;
 }
 
 h1, h2, h3, h4,
 h5, h6, a, p {
-  color: #212529;
-  font-family: "Rajdhani", sans-serif;
-  line-height: 1em;
+  color: var(--text-primary);
+  font-family: var(--font-primary);
+  line-height: 1.3;
 }
 
 h1, h2, h3, h4,
 h5, h6 {
   font-weight: 700;
+  font-family: var(--font-accent);
 }
 
-p a {
-  color: #4ff461;
+p a,
+a {
+  color: var(--text-link);
   font-weight: 600;
+}
+
+a:hover {
+  color: var(--text-link-hover);
+  text-decoration: none;
 }
 
 p .reaction {
@@ -1976,11 +2006,6 @@ p .reaction {
 
 p .reaction:first-child {
   margin-left: 0;
-}
-
-a:hover {
-  color: #4ff461;
-  text-decoration: none;
 }
 
 figure > img {

--- a/module/chat/chat.css
+++ b/module/chat/chat.css
@@ -4,22 +4,24 @@ module[data-module="chat"] {
   right: 72px;
   width: 360px;
   height: calc(100vh - 80px);
-  background: #fff;
-  box-shadow: -4px 0 8px rgba(0, 0, 0, 0.1);
+  background: var(--bg-floating);
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.35);
   display: flex;
   flex-direction: column;
   font-size: 14px;
   z-index: 1030;
+  color: var(--text-primary);
 }
 
 module[data-module="chat"] .chat-header {
-  padding: 8px 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--surface-border);
 }
 
 module[data-module="chat"] .chat-dono-scroller {
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
-  padding: 4px 12px;
+  border-top: 1px solid var(--surface-border);
+  border-bottom: 1px solid var(--surface-border);
+  padding: 6px 16px;
   display: flex;
   gap: 0.5rem;
   flex-wrap: nowrap;
@@ -35,25 +37,35 @@ module[data-module="chat"] .chat-dono-scroller::-webkit-scrollbar {
 }
 
 module[data-module="chat"] .chat-header .title {
-  font-weight: 600;
+  font-weight: 700;
+  font-family: var(--font-accent);
 }
 
 module[data-module="chat"] .chat-header .meta {
   font-size: 12px;
-  color: #666;
+  color: var(--text-muted);
 }
 
 module[data-module="chat"] .chat-body {
   flex: 1;
   overflow-y: auto;
-  padding: 8px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 module[data-module="chat"] .chat-message {
   display: flex;
   gap: 8px;
-  margin-bottom: 4px;
   align-items: flex-start;
+  padding: 6px 8px;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
+}
+
+module[data-module="chat"] .chat-message:hover {
+  background-color: var(--interactive-hover);
 }
 
 module[data-module="chat"] .msg-avatar {
@@ -102,12 +114,13 @@ module[data-module="chat"] .user-meta {
 }
 
 module[data-module="chat"] .chat-message .time {
-  color: #888;
+  color: var(--text-muted);
   font-size: 12px;
 }
 
 module[data-module="chat"] .chat-message .name {
   font-weight: 600;
+  font-family: var(--font-primary);
 }
 
 module[data-module="chat"] .badges {
@@ -122,9 +135,9 @@ module[data-module="chat"] .badges img {
 }
 
 module[data-module="chat"] .chat-message.sticker {
-  background: #f8f8f8;
-  border-radius: 6px;
-  padding: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 8px;
+  padding: 6px;
 }
 
 module[data-module="chat"] .chat-message.sticker .sticker-meta {
@@ -146,29 +159,30 @@ module[data-module="chat"] .chat-message.sticker .sticker {
 }
 
 module[data-module="chat"] .chat-form {
-  padding: 8px;
-  border-top: 1px solid #ddd;
+  padding: 12px 16px 16px;
+  border-top: 1px solid var(--surface-border);
   position: relative;
-}
+  }
 
 module[data-module="chat"] .chat-input-group {
-  border: 1px solid #ccc;
-  border-radius: 6px;
+  border: 1px solid var(--surface-border);
+  border-radius: 12px;
+  background-color: var(--bg-elevated);
 }
 
 module[data-module="chat"] .chat-input-top {
   display: flex;
   align-items: center;
-  padding: 8px;
-  border-bottom: 1px solid #ddd;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--surface-border-subtle);
 }
 
 module[data-module="chat"] .chat-avatar {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #933;
-  color: #fff;
+  background: var(--accent);
+  color: var(--text-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -184,6 +198,7 @@ module[data-module="chat"] .chat-input-wrapper {
 module[data-module="chat"] .chat-user {
   font-weight: 600;
   font-size: 12px;
+  color: var(--text-muted);
 }
 
 module[data-module="chat"] .chat-input {
@@ -191,13 +206,15 @@ module[data-module="chat"] .chat-input {
   border: none;
   outline: none;
   padding: 0;
+  background: transparent;
+  color: var(--text-primary);
 }
 
 module[data-module="chat"] .chat-input-bottom {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 4px 8px;
+  padding: 8px 12px;
 }
 
 module[data-module="chat"] .chat-actions {
@@ -217,6 +234,9 @@ module[data-module="chat"] .chat-actions button {
   border: none;
   cursor: pointer;
   padding: 4px;
+  color: var(--text-muted);
+  border-radius: 6px;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 module[data-module="chat"] .chat-actions button {
@@ -229,31 +249,40 @@ module[data-module="chat"] .chat-tools button {
   font-size: 18px;
 }
 
+module[data-module="chat"] .chat-tools button:hover,
+module[data-module="chat"] .chat-actions button:hover,
+module[data-module="chat"] .chat-tools button:focus-visible,
+module[data-module="chat"] .chat-actions button:focus-visible {
+  background: var(--interactive-hover);
+  color: var(--text-primary);
+  outline: none;
+}
+
 module[data-module="chat"] .chat-count {
   font-size: 12px;
-  color: #666;
+  color: var(--text-muted);
   margin-right: 8px;
 }
 
 module[data-module="chat"] .chat-send-icon {
   width: 20px;
   height: 20px;
-  fill: #06c;
+  fill: var(--accent);
 }
 
 module[data-module="chat"] .chat-hide {
-  border-top: 1px solid #ddd;
+  border-top: 1px solid var(--surface-border);
   width: 100%;
   text-align: center;
-  color: #06c;
+  color: var(--text-link);
   padding: 6px;
-  background: #fff;
+  background: var(--bg-elevated);
 }
 
 module[data-module="chat"] .chat-donation {
-  background: #e9ffe5;
-  border-radius: 6px;
-  padding: 8px;
+  background: rgba(88, 101, 242, 0.18);
+  border-radius: 8px;
+  padding: 8px 10px;
   margin: 4px 0;
 }
 
@@ -268,11 +297,11 @@ module[data-module="chat"] .dono-pill {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  background: var(--accent, #1a2232);
-  color: #fff;
+  background: var(--accent);
+  color: var(--text-primary);
   border-radius: 9999px;
   padding: 0.25rem 0.5rem 0.25rem 0.25rem;
-  font-family: "Rajdhani", sans-serif;
+  font-family: var(--font-accent);
   font-weight: 600;
   overflow: hidden;
 }
@@ -292,8 +321,8 @@ module[data-module="chat"] .dono-pill .avatar {
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  background: #fff;
-  color: #1a2232;
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--text-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -313,8 +342,8 @@ module[data-module="chat"] .chat-drawer {
   left: 0;
   right: 0;
   bottom: 100%;
-  background: #fff;
-  border-top: 1px solid #ddd;
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--surface-border);
   transform: translateY(100%);
   transition: transform 0.2s ease, opacity 0.2s ease;
   display: flex;
@@ -343,16 +372,19 @@ module[data-module="chat"] .emote-set-header {
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
+  color: var(--text-muted);
 }
 
 module[data-module="chat"] .emote-set-header .streamer-avatar {
   width: 24px;
   height: 24px;
   border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--surface-border-subtle);
 }
 
 module[data-module="chat"] .emote-set-header .streamer-name {
   font-weight: 600;
+  color: var(--text-primary);
 }
 
 module[data-module="chat"] .emote-list {
@@ -366,6 +398,8 @@ module[data-module="chat"] .emote-list .emote {
   border: none;
   background: none;
   cursor: pointer;
+  border-radius: 6px;
+  transition: background-color 0.2s ease;
 }
 
 module[data-module="chat"] .emote-list .emote img {
@@ -373,8 +407,14 @@ module[data-module="chat"] .emote-list .emote img {
   height: 32px;
 }
 
+module[data-module="chat"] .emote-list .emote:hover,
+module[data-module="chat"] .emote-list .emote:focus-visible {
+  background: var(--interactive-hover);
+  outline: none;
+}
+
 module[data-module="chat"] .resonance-grid {
-  padding: 8px;
+  padding: 8px 12px;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(64px, 1fr));
   gap: 8px;
@@ -382,13 +422,21 @@ module[data-module="chat"] .resonance-grid {
 
 module[data-module="chat"] .resonance-item {
   border: none;
-  background: #f8f8f8;
-  border-radius: 6px;
-  padding: 4px;
+  background: var(--interactive-hover);
+  border-radius: 10px;
+  padding: 6px;
   display: flex;
   flex-direction: column;
   align-items: center;
   cursor: pointer;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+module[data-module="chat"] .resonance-item:hover,
+module[data-module="chat"] .resonance-item:focus-visible {
+  transform: translateY(-2px);
+  background: var(--interactive-active);
+  outline: none;
 }
 
 module[data-module="chat"] .resonance-item .resonance-sticker {
@@ -403,6 +451,7 @@ module[data-module="chat"] .resonance-cost {
   gap: 4px;
   font-weight: 600;
   margin-top: 4px;
+  color: var(--text-primary);
 }
 
 module[data-module="chat"] .resonance-cost .resonance-badge {
@@ -439,9 +488,10 @@ module[data-module="chat"] .resonance-use-effects {
 }
 
 module[data-module="chat"] .resonance-use-effects li {
-  background: #f0f0f0;
+  background: var(--interactive-hover);
   padding: 2px 6px;
   border-radius: 4px;
+  color: var(--text-muted);
 }
 
 module[data-module="chat"] .resonance-use-actions {
@@ -454,11 +504,27 @@ module[data-module="chat"] .resonance-use-actions button {
   flex: 1;
   padding: 4px 8px;
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 module[data-module="chat"] .resonance-use-actions .resonance-use-btn {
-  background: #06c;
-  color: #fff;
+  background: var(--accent);
+  color: var(--text-primary);
+}
+
+module[data-module="chat"] .resonance-use-actions .resonance-use-btn:hover {
+  background: var(--accent-hover);
+}
+
+module[data-module="chat"] .resonance-use-actions .resonance-cancel-btn {
+  background: var(--interactive-hover);
+  color: var(--text-muted);
+}
+
+module[data-module="chat"] .resonance-use-actions .resonance-cancel-btn:hover {
+  background: var(--interactive-active);
+  color: var(--text-primary);
 }

--- a/module/header/header.css
+++ b/module/header/header.css
@@ -10,10 +10,12 @@
   width: 100%;
   height: 80px;
   z-index: 1000;
-  background-color: #6330f5;
+  background-color: var(--bg-floating);
+  border-bottom: 1px solid var(--surface-border);
   display: flex;
   align-items: center;
   padding: 0 20px;
+  gap: 20px;
 }
 
 [data-role="header"] .header-actions {
@@ -33,26 +35,27 @@
 [data-role="header"] .header-brand .logo {
   width: 40px;
   height: 40px;
-  fill: #fff;
+  fill: var(--text-primary);
 }
 
 [data-role="header"] .header-brand-text {
   margin-left: 26px;
-  color: #fff;
-  font-family: "Titillium Web", sans-serif;
+  color: var(--text-primary);
+  font-family: var(--font-accent);
   font-size: 1.25rem;
   font-weight: 900;
   text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 [data-role="header"] .navigation .icon-dots {
-  fill: #fff;
+  fill: var(--text-muted);
 }
 
 [data-role="header"] .navigation .menu-main {
   display: flex;
   margin-left: 30px;
-  gap: 20px;
+  gap: 16px;
   align-items: center;
   list-style: none;
   padding-left: 0;
@@ -60,13 +63,15 @@
 }
 
 [data-role="header"] .menu-main-item-link {
-  color: #fff;
-  font-family: "Rajdhani", sans-serif;
-  font-weight: 500;
+  color: var(--text-muted);
+  font-family: var(--font-primary);
+  font-weight: 600;
   background: none;
   border: none;
-  padding: 0;
+  padding: 8px 12px;
+  border-radius: 8px;
   text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 [data-role="header"] .menu-main-item-link.dropdown-toggle::after {
@@ -75,13 +80,13 @@
 
 [data-role="header"] .menu-main-item-link:hover,
 [data-role="header"] .menu-main-item-link:focus {
-  color: #fff;
-  opacity: 0.85;
+  color: var(--text-primary);
+  background-color: var(--interactive-hover);
 }
 
 [data-role="header"] .search-bar {
   flex: 1;
-  padding: 0 40px;
+  padding: 0 24px;
   position: relative;
 }
 
@@ -92,18 +97,44 @@
 
 [data-role="header"] .search-bar .interactive-input input {
   width: 100%;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  background: var(--interactive-muted);
+  border: 1px solid transparent;
+  color: var(--text-primary);
+  border-radius: 20px;
+  box-shadow: none;
   padding-right: 3rem;
   padding-left: 3rem;
-  height: 48px;
+  height: 44px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+[data-role="header"] .search-bar .interactive-input input:focus {
+  border-color: var(--accent);
+  background-color: rgba(88, 101, 242, 0.08);
+  outline: none;
+}
+
+[data-role="header"] .navigation .dropdown-menu {
+  background-color: var(--bg-floating);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-elevated);
+  padding: 0.5rem 0;
+}
+
+[data-role="header"] .navigation .dropdown-item {
+  color: var(--text-primary);
+  font-family: var(--font-primary);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+[data-role="header"] .navigation .dropdown-item:hover,
+[data-role="header"] .navigation .dropdown-item:focus {
+  background-color: var(--interactive-hover);
+  color: var(--text-primary);
 }
 
 [data-role="header"] .search-bar .interactive-input input::placeholder {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted);
 }
 
 [data-role="header"] .search-bar .interactive-input-icon-wrap,
@@ -125,7 +156,7 @@
 }
 
 [data-role="header"] .search-bar .interactive-input-icon {
-  fill: #fff;
+  fill: var(--text-muted);
 }
 
 [data-role="header"] .search-bar .interactive-input-action {
@@ -135,7 +166,7 @@
 }
 
 [data-role="header"] .search-bar .interactive-input-action-icon {
-  fill: #fff;
+  fill: var(--text-muted);
 }
 
 [data-role="header"] .search-bar .interactive-input.active .interactive-input-action {
@@ -151,16 +182,17 @@
   overflow-y: auto;
   padding: 0.5rem 0;
   margin-top: 12px;
-  background-color: #fff;
+  background-color: var(--bg-floating);
+  border: 1px solid var(--surface-border);
   border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-elevated);
 }
 
 [data-role="header"] .header-search-category {
   padding: 0.5rem 1rem;
   font-size: 0.75rem;
   font-weight: 700;
-  color: #6c757d;
+  color: var(--text-muted);
   text-transform: uppercase;
 }
 
@@ -169,6 +201,12 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.5rem 1rem;
+  color: var(--text-primary);
+  transition: background-color 0.2s ease;
+}
+
+[data-role="header"] .header-search-item:hover {
+  background-color: var(--interactive-hover);
 }
 
 [data-role="header"] .header-search-item img {
@@ -188,7 +226,7 @@
 
 [data-role="header"] .header-search-item .meta {
   font-size: 0.75rem;
-  color: #6c757d;
+  color: var(--text-muted);
 }
 
 [data-role="header"] .quest-trigger {
@@ -396,7 +434,7 @@
 
 [data-role="header"] .quest-progress {
   height: 100%;
-  background-color: #6330f5;
+  background-color: var(--accent);
   border-radius: inherit;
 }
 
@@ -418,14 +456,24 @@
 [data-role="header"] .action-list-item {
   background: none;
   border: none;
-  padding: 0;
+  padding: 8px;
+  border-radius: 50%;
+  color: var(--text-muted);
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 [data-role="header"] .settings-button {
   margin-left: 30px;
 }
 [data-role="header"] .action-list-item .icon {
-  fill: #fff;
+  fill: currentColor;
+}
+
+[data-role="header"] .action-list-item:hover,
+[data-role="header"] .action-list-item:focus-visible {
+  color: var(--text-primary);
+  background-color: var(--interactive-hover);
+  outline: none;
 }
 
 

--- a/module/navigation/navigation.css
+++ b/module/navigation/navigation.css
@@ -5,11 +5,11 @@
   height: calc(100vh - 80px);
   width: 80px;
   padding-top: 20px;
-  background-color: #ffffff;
+  background-color: var(--bg-elevated);
   display: flex;
   flex-direction: column;
   align-items: center;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid var(--surface-border);
   z-index: 1040;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
@@ -41,14 +41,21 @@
   justify-content: center;
   width: 48px;
   height: 48px;
-  color: #8b97b7;
+  color: var(--text-muted);
   border-radius: 12px;
   text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.1s ease;
 }
-.navigation-small-link:hover {
-  background-color: #f0f2f5;
-  color: #1f2937;
+
+.navigation-small-link .icon {
+  fill: currentColor;
+}
+.navigation-small-link:hover,
+.navigation-small-link:focus-visible {
+  background-color: var(--interactive-hover);
+  color: var(--text-primary);
+  outline: none;
+  transform: translateY(-1px);
 }
 /* Tooltip rendered via JavaScript */
 .navigation-small-tooltip {
@@ -56,8 +63,8 @@
   left: 0;
   top: 0;
   transform: translateY(-50%) translateX(10px);
-  background-color: #1d2333;
-  color: #fff;
+  background-color: var(--bg-floating);
+  color: var(--text-primary);
   padding: 4px 8px;
   border-radius: 12px;
   font-size: 14px;
@@ -79,8 +86,8 @@
   left: 10px;
   height: calc(100vh - 80px);
   width: 265px;
-  background-color: #ffffff;
-  border-right: 1px solid #e5e7eb;
+  background-color: var(--bg-elevated);
+  border-right: 1px solid var(--surface-border);
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   z-index: 1030;
@@ -112,15 +119,16 @@
 
 
 .navigation-large-profile .user-name {
-  font-family: "Rajdhani", sans-serif;
+  font-family: var(--font-accent);
   font-weight: 700;
   font-size: 1.125rem;
   margin-bottom: 0;
+  color: var(--text-primary);
 }
 
 .navigation-large-profile .user-url {
   font-size: 0.875rem;
-  color: #8b97b7;
+  color: var(--text-muted);
   margin-bottom: 20px;
 }
 
@@ -129,7 +137,7 @@
   list-style: none;
   padding: 0;
   margin: 0 0 30px;
-  background-color: #1d2333;
+  background-color: var(--bg-floating);
   border-radius: 12px;
   overflow: hidden;
 }
@@ -141,21 +149,21 @@
 }
 
 .profile-stat:not(:last-child) {
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  border-right: 1px solid var(--surface-border-subtle);
 }
 
 .profile-stat .stat-value {
   display: block;
-  font-family: "Rajdhani", sans-serif;
+  font-family: var(--font-accent);
   font-weight: 700;
   font-size: 0.875rem;
-  color: #e5e7eb;
+  color: var(--text-primary);
 }
 
 .profile-stat .stat-label {
   display: block;
   font-size: 0.75rem;
-  color: #8b97b7;
+  color: var(--text-muted);
   text-transform: uppercase;
 }
 
@@ -166,6 +174,7 @@
   list-style: none;
   padding: 0;
   margin: 0 0 30px;
+  color: var(--text-muted);
 }
 
 .user-badges .badge-icon {
@@ -185,11 +194,11 @@
   display: flex;
   align-items: center;
   padding: 12px 20px;
-  color: #1f2937;
+  color: var(--text-muted);
   text-decoration: none;
-  font-family: "Rajdhani", sans-serif;
+  font-family: var(--font-primary);
   font-weight: 500;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .navigation-large-link .icon {
@@ -197,9 +206,11 @@
   fill: currentColor;
 }
 
-.navigation-large-link:hover {
-  background-color: #f0f2f5;
-  color: #1f2937;
+.navigation-large-link:hover,
+.navigation-large-link:focus-visible {
+  background-color: var(--interactive-hover);
+  color: var(--text-primary);
+  outline: none;
 }
 
 @media (max-width: 991.98px) {

--- a/module/user-rail/user-rail.css
+++ b/module/user-rail/user-rail.css
@@ -5,8 +5,8 @@ module[data-module="user-rail"] {
   height: calc(100vh - 80px);
   width: 72px;
   z-index: 1040;
-  background: #fff;
-  box-shadow: -4px 0 8px rgba(0, 0, 0, 0.1);
+  background: var(--bg-elevated);
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.35);
   padding: 16px 0;
   display: flex;
   --avi-width: 40px;
@@ -66,7 +66,7 @@ module[data-module="user-rail"] .user-rail-item::before {
   top: 50%;
   width: var(--indicator-width);
   height: 0;
-  background: var(--accent, #ff72b6);
+  background: var(--accent);
   border-radius: 0 10px 10px 0;
   transform: translateY(-50%);
   opacity: 0;


### PR DESCRIPTION
## Summary
- introduce Discord-inspired theme tokens and typography to the global stylesheet while keeping the legacy layout intact
- restyle header, navigation, chat, and user rail modules to consume the shared dark palette and interactive states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e52b27f40c8324886d5aec93388501