### PR TITLE
Update user rail avatars with frames

### DIFF
--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -3,7 +3,7 @@
   "token": "john-viking",
   "name": "John Viking",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/05.jpg",
-  "frame": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id%3D'g' cx%3D'50%' cy%3D'50%' r%3D'65%'%3E%3Cstop offset%3D'0%' stop-color%3D'#aaffd3' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'65%' stop-color%3D'#72ffb6' stop-opacity%3D'1'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#3d775e' stop-opacity%3D'1'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Ccircle cx%3D'50' cy%3D'50' r%3D'46' fill%3D'none' stroke%3D'url%28#g%29' stroke-width%3D'8' stroke-linecap%3D'round'%2F%3E%3C%2Fsvg%3E",
+  "frame": "images/frames/aurora.png",
   "banner": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 600 240'%3E%3Cdefs%3E%3ClinearGradient id%3D'bg' x1%3D'0%' y1%3D'0%' x2%3D'100%' y2%3D'100%'%3E%3Cstop offset%3D'0%' stop-color%3D'#95ffc8'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#2e614b'%2F%3E%3C%2FlinearGradient%3E%3CradialGradient id%3D'flare' cx%3D'20%' cy%3D'20%' r%3D'80%'%3E%3Cstop offset%3D'0%' stop-color%3D'#95ffc8' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#2e614b' stop-opacity%3D'0'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Crect width%3D'600' height%3D'240' fill%3D'url%28#bg%29'%2F%3E%3Ccircle cx%3D'80' cy%3D'60' r%3D'180' fill%3D'url%28#flare%29'%2F%3E%3Ccircle cx%3D'520' cy%3D'200' r%3D'140' fill%3D'url%28#flare%29' opacity%3D'0.6'%2F%3E%3C%2Fsvg%3E",
   "hasNotification": false,
   "accent": "#72ffb6",

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -3,7 +3,7 @@
   "token": "marina-valentine",
   "name": "Marina Valentine",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/01.jpg",
-  "frame": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id%3D'g' cx%3D'50%' cy%3D'50%' r%3D'65%'%3E%3Cstop offset%3D'0%' stop-color%3D'#ffaad3' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'65%' stop-color%3D'#ff72b6' stop-opacity%3D'1'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#763e5e' stop-opacity%3D'1'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Ccircle cx%3D'50' cy%3D'50' r%3D'46' fill%3D'none' stroke%3D'url%28#g%29' stroke-width%3D'8' stroke-linecap%3D'round'%2F%3E%3C%2Fsvg%3E",
+  "frame": "images/frames/sakura_ink.png",
   "banner": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 600 240'%3E%3Cdefs%3E%3ClinearGradient id%3D'bg' x1%3D'0%' y1%3D'0%' x2%3D'100%' y2%3D'100%'%3E%3Cstop offset%3D'0%' stop-color%3D'#ff95c8'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#60304b'%2F%3E%3C%2FlinearGradient%3E%3CradialGradient id%3D'flare' cx%3D'20%' cy%3D'20%' r%3D'80%'%3E%3Cstop offset%3D'0%' stop-color%3D'#ff95c8' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#60304b' stop-opacity%3D'0'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Crect width%3D'600' height%3D'240' fill%3D'url%28#bg%29'%2F%3E%3Ccircle cx%3D'80' cy%3D'60' r%3D'180' fill%3D'url%28#flare%29'%2F%3E%3Ccircle cx%3D'520' cy%3D'200' r%3D'140' fill%3D'url%28#flare%29' opacity%3D'0.6'%2F%3E%3C%2Fsvg%3E",
   "hasNotification": true,
   "accent": "#ff72b6",

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -3,7 +3,7 @@
   "token": "neko-bebop",
   "name": "Neko Bebop",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/02.jpg",
-  "frame": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id%3D'g' cx%3D'50%' cy%3D'50%' r%3D'65%'%3E%3Cstop offset%3D'0%' stop-color%3D'#b9d2ff' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'65%' stop-color%3D'#8ab4ff' stop-opacity%3D'1'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#47597c' stop-opacity%3D'1'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Ccircle cx%3D'50' cy%3D'50' r%3D'46' fill%3D'none' stroke%3D'url%28#g%29' stroke-width%3D'8' stroke-linecap%3D'round'%2F%3E%3C%2Fsvg%3E",
+  "frame": "images/frames/neon_cat_hoodie_blue.png",
   "banner": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 600 240'%3E%3Cdefs%3E%3ClinearGradient id%3D'bg' x1%3D'0%' y1%3D'0%' x2%3D'100%' y2%3D'100%'%3E%3Cstop offset%3D'0%' stop-color%3D'#a7c7ff'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#374765'%2F%3E%3C%2FlinearGradient%3E%3CradialGradient id%3D'flare' cx%3D'20%' cy%3D'20%' r%3D'80%'%3E%3Cstop offset%3D'0%' stop-color%3D'#a7c7ff' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#374765' stop-opacity%3D'0'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Crect width%3D'600' height%3D'240' fill%3D'url%28#bg%29'%2F%3E%3Ccircle cx%3D'80' cy%3D'60' r%3D'180' fill%3D'url%28#flare%29'%2F%3E%3Ccircle cx%3D'520' cy%3D'200' r%3D'140' fill%3D'url%28#flare%29' opacity%3D'0.6'%2F%3E%3C%2Fsvg%3E",
   "hasNotification": false,
   "accent": "#8ab4ff",

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -3,7 +3,7 @@
   "token": "nick-grissom",
   "name": "Nick Grissom",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/03.jpg",
-  "frame": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id%3D'g' cx%3D'50%' cy%3D'50%' r%3D'65%'%3E%3Cstop offset%3D'0%' stop-color%3D'#ffe39b' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'65%' stop-color%3D'#ffd059' stop-opacity%3D'1'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#766439' stop-opacity%3D'1'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Ccircle cx%3D'50' cy%3D'50' r%3D'46' fill%3D'none' stroke%3D'url%28#g%29' stroke-width%3D'8' stroke-linecap%3D'round'%2F%3E%3C%2Fsvg%3E",
+  "frame": "images/frames/new_year_2024.png",
   "banner": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 600 240'%3E%3Cdefs%3E%3ClinearGradient id%3D'bg' x1%3D'0%' y1%3D'0%' x2%3D'100%' y2%3D'100%'%3E%3Cstop offset%3D'0%' stop-color%3D'#ffdc82'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#60512b'%2F%3E%3C%2FlinearGradient%3E%3CradialGradient id%3D'flare' cx%3D'20%' cy%3D'20%' r%3D'80%'%3E%3Cstop offset%3D'0%' stop-color%3D'#ffdc82' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#60512b' stop-opacity%3D'0'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Crect width%3D'600' height%3D'240' fill%3D'url%28#bg%29'%2F%3E%3Ccircle cx%3D'80' cy%3D'60' r%3D'180' fill%3D'url%28#flare%29'%2F%3E%3Ccircle cx%3D'520' cy%3D'200' r%3D'140' fill%3D'url%28#flare%29' opacity%3D'0.6'%2F%3E%3C%2Fsvg%3E",
   "hasNotification": false,
   "accent": "#ffd059",

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -3,7 +3,7 @@
   "token": "sarah-diamond",
   "name": "Sarah Diamond",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/04.jpg",
-  "frame": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 100 100'%3E%3Cdefs%3E%3CradialGradient id%3D'g' cx%3D'50%' cy%3D'50%' r%3D'65%'%3E%3Cstop offset%3D'0%' stop-color%3D'#d0a7ff' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'65%' stop-color%3D'#b06dff' stop-opacity%3D'1'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#563c7c' stop-opacity%3D'1'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Ccircle cx%3D'50' cy%3D'50' r%3D'46' fill%3D'none' stroke%3D'url%28#g%29' stroke-width%3D'8' stroke-linecap%3D'round'%2F%3E%3C%2Fsvg%3E",
+  "frame": "images/frames/spirit_blossom_morgana.png",
   "banner": "data:image/svg+xml;utf8,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' viewBox%3D'0 0 600 240'%3E%3Cdefs%3E%3ClinearGradient id%3D'bg' x1%3D'0%' y1%3D'0%' x2%3D'100%' y2%3D'100%'%3E%3Cstop offset%3D'0%' stop-color%3D'#c492ff'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#442e65'%2F%3E%3C%2FlinearGradient%3E%3CradialGradient id%3D'flare' cx%3D'20%' cy%3D'20%' r%3D'80%'%3E%3Cstop offset%3D'0%' stop-color%3D'#c492ff' stop-opacity%3D'0.9'%2F%3E%3Cstop offset%3D'100%' stop-color%3D'#442e65' stop-opacity%3D'0'%2F%3E%3C%2FradialGradient%3E%3C%2Fdefs%3E%3Crect width%3D'600' height%3D'240' fill%3D'url%28#bg%29'%2F%3E%3Ccircle cx%3D'80' cy%3D'60' r%3D'180' fill%3D'url%28#flare%29'%2F%3E%3Ccircle cx%3D'520' cy%3D'200' r%3D'140' fill%3D'url%28#flare%29' opacity%3D'0.6'%2F%3E%3C%2Fsvg%3E",
   "hasNotification": false,
   "accent": "#b06dff",

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -14,14 +14,17 @@ export default async function init({ hub, root, utils }) {
     <nav class="user-rail">
       <ul class="user-rail-list">
         ${users
-          .map(
-            (u, i) => `
+          .map((u, i) => {
+            const frameStyle = u.frame
+              ? `--frame:url('${u.frame}'); --frame-opacity:1; --frame-bleed:18%;`
+              : '--frame:none; --frame-opacity:0;';
+            return `
         <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-token="${u.token}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-bio="${u.bio || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}">
-          <div class="avatar-wrap" style="--frame:url('${u.frame}');">
+          <div class="avatar-wrap" style="${frameStyle}">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>
-        </li>`
-          )
+        </li>`;
+          })
           .join('')}
       </ul>
     </nav>


### PR DESCRIPTION
## Summary
- use frame artwork from the local frames directory for rail users
- ensure the user rail avatar markup applies the frame styles so the artwork stays visible while keeping unread indicators intact

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e689668464832499d91bacc9f21ab3