### PR TITLE
Refine mock layout styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,903 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Workspace Mock</title>
 
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+
+  <style>
+    :root {
+      --app-bg: #e4e5e8;
+      --rail-track: #f0f0f3;
+      --rail-border: #d7d8dc;
+      --rail-bubble: #cfd0d6;
+      --rail-active: #3d3e42;
+      --rail-accent: #ff596f;
+      --panel: #ffffff;
+      --panel-soft: #f9f9fb;
+      --panel-border: #d8d9de;
+      --panel-line: #ededf1;
+      --text-strong: #1f2024;
+      --text-body: #4d5056;
+      --text-muted: #7d8088;
+      --presence: #21cf6c;
+      --warning: #f5a623;
+      --shadow: 0 12px 24px rgba(18, 19, 24, 0.08);
+      --radius-lg: 22px;
+      --radius-md: 16px;
+      --radius-sm: 12px;
+      --chrome: 56px;
+    }
+
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      background: var(--app-bg);
+      color: var(--text-strong);
+      font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      overflow: hidden;
+    }
+
+    .titlebar {
+      height: 34px;
+      background: linear-gradient(0deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.75));
+      border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+    }
+
+    .app-grid {
+      height: calc(100dvh - 34px);
+      display: grid;
+      grid-template-columns: 84px minmax(880px, 1fr) 320px;
+      gap: 1rem;
+      padding: 1rem 1.25rem 1rem 0.75rem;
+    }
+
+    /* rail */
+    .server-rail {
+      width: 84px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      position: relative;
+      gap: 0.75rem;
+    }
+
+    .server-rail .home {
+      width: 58px;
+      height: 58px;
+      border-radius: 18px;
+      margin-left: 0.8rem;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      font-size: 1.1rem;
+      color: #fff;
+      background: linear-gradient(135deg, #202128 5%, #0d0d11 94%);
+      box-shadow: 0 18px 28px rgba(18, 19, 25, 0.28);
+      letter-spacing: 0.02em;
+    }
+
+    .server-rail .divider {
+      width: 58px;
+      height: 1px;
+      margin-left: 0.8rem;
+      background: rgba(0, 0, 0, 0.18);
+    }
+
+    .rail-track {
+      position: relative;
+      flex: 1 1 auto;
+      margin-left: 0.8rem;
+      width: 68px;
+      background: var(--rail-track);
+      border: 1px solid var(--rail-border);
+      border-radius: 26px;
+      padding: 0.9rem 0.55rem;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), var(--shadow);
+      overflow: hidden;
+    }
+
+    .rail-track::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      border: 1px solid rgba(255, 255, 255, 0.65);
+      pointer-events: none;
+    }
+
+    .rail-scroll {
+      height: 100%;
+      overflow-y: auto;
+      padding-right: 2px;
+    }
+
+    .rail-scroll::-webkit-scrollbar {
+      width: 4px;
+    }
+
+    .rail-scroll::-webkit-scrollbar-thumb {
+      background: rgba(0, 0, 0, 0.14);
+      border-radius: 999px;
+    }
+
+    .server-dot {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      margin: 0.55rem auto;
+      background: var(--rail-bubble);
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      position: relative;
+      transition: transform 0.2s ease;
+    }
+
+    .server-dot.round {
+      border-radius: 50%;
+    }
+
+    .server-dot.active {
+      background: var(--rail-active);
+      border-color: transparent;
+      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.08);
+    }
+
+    .server-dot .badge {
+      position: absolute;
+      min-width: 18px;
+      height: 18px;
+      line-height: 18px;
+      right: -5px;
+      bottom: -5px;
+      font-size: 0.62rem;
+      letter-spacing: 0.03em;
+      background: var(--rail-accent);
+      color: #fff;
+      border-radius: 999px;
+      font-weight: 600;
+      padding: 0 0.35rem;
+      box-shadow: 0 6px 12px rgba(255, 89, 111, 0.35);
+    }
+
+    .rail-new {
+      position: absolute;
+      bottom: 0.55rem;
+      left: 0.9rem;
+      width: 62px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, #ff7b83, #ff5b6d);
+      color: #fff;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-align: center;
+      padding: 0.3rem 0;
+      letter-spacing: 0.08em;
+      box-shadow: 0 16px 28px rgba(255, 90, 110, 0.28);
+    }
+
+    /* layout columns */
+    .workspace {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      min-width: 0;
+    }
+
+    .workspace-header {
+      display: grid;
+      grid-template-columns: 320px 1fr 320px;
+      gap: 1rem;
+    }
+
+    .bubble {
+      height: var(--chrome);
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow);
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      gap: 0.75rem;
+    }
+
+    .bubble .pill {
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      border: 1px solid var(--panel-border);
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      background: var(--panel-soft);
+    }
+
+    .bubble .status-dot {
+      width: 30px;
+      height: 30px;
+      border-radius: 10px;
+      background: var(--rail-bubble);
+      position: relative;
+    }
+
+    .bubble .status-dot::after {
+      content: "";
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      background: var(--presence);
+      right: -2px;
+      bottom: -2px;
+    }
+
+    .header-search {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      justify-content: flex-end;
+    }
+
+    .search-pill {
+      flex: 1 1 auto;
+      max-width: 240px;
+      border-radius: 999px;
+      background: var(--panel-soft);
+      border: 1px solid var(--panel-border);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0 0.75rem;
+      height: var(--chrome);
+    }
+
+    .search-pill input {
+      border: 0;
+      background: transparent;
+      outline: none;
+      font-size: 0.9rem;
+      color: var(--text-body);
+    }
+
+    .search-pill i {
+      color: var(--text-muted);
+    }
+
+    .icon-btn {
+      width: var(--chrome);
+      height: var(--chrome);
+      border-radius: var(--radius-md);
+      border: 1px solid var(--panel-border);
+      background: var(--panel);
+      display: grid;
+      place-items: center;
+      color: var(--text-muted);
+      box-shadow: var(--shadow);
+    }
+
+    .main-panels {
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      gap: 1rem;
+      min-height: 0;
+      flex: 1 1 auto;
+    }
+
+    .nav-pane {
+      display: grid;
+      grid-template-rows: var(--chrome) 1fr var(--chrome);
+      background: var(--panel-soft);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--panel-border);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .nav-pane header,
+    .nav-pane footer {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0 1rem;
+      background: rgba(255, 255, 255, 0.75);
+      border-bottom: 1px solid var(--panel-border);
+    }
+
+    .nav-pane footer {
+      border-top: 1px solid var(--panel-border);
+      border-bottom: 0;
+      background: rgba(255, 255, 255, 0.65);
+      justify-content: space-between;
+    }
+
+    .nav-pane .scroll {
+      padding: 1rem;
+      overflow-y: auto;
+      border-bottom: 1px solid var(--panel-border);
+    }
+
+    .category {
+      text-transform: uppercase;
+      font-size: 0.72rem;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+      margin-bottom: 0.35rem;
+    }
+
+    .channel {
+      height: 44px;
+      border-radius: var(--radius-sm);
+      border: 1px solid transparent;
+      background: transparent;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0 0.85rem;
+      color: var(--text-body);
+      transition: background 0.18s ease, border 0.18s ease;
+    }
+
+    .channel.active {
+      background: var(--panel);
+      border-color: var(--panel-border);
+      box-shadow: var(--shadow);
+    }
+
+    .channel .hash {
+      width: 24px;
+      height: 24px;
+      border-radius: 8px;
+      background: #d7d8dd;
+      display: grid;
+      place-items: center;
+      font-weight: 600;
+      color: var(--text-strong);
+    }
+
+    .channel .meta {
+      margin-left: auto;
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .chat-pane {
+      display: grid;
+      grid-template-rows: var(--chrome) 1fr var(--chrome);
+      border-radius: var(--radius-lg);
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      min-width: 0;
+    }
+
+    .chat-pane .chat-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0 1.25rem;
+      border-bottom: 1px solid var(--panel-border);
+      background: rgba(255, 255, 255, 0.85);
+    }
+
+    .chat-pane .chat-header .tag {
+      padding: 0.2rem 0.75rem;
+      border-radius: 999px;
+      border: 1px solid var(--panel-border);
+      font-size: 0.75rem;
+      background: var(--panel-soft);
+      color: var(--text-muted);
+    }
+
+    .chat-scroll {
+      overflow-y: auto;
+      background: var(--panel-soft);
+      padding: 1.25rem 1.5rem 1.5rem;
+    }
+
+    .timeline-divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-transform: uppercase;
+      font-size: 0.75rem;
+      letter-spacing: 0.2em;
+      color: var(--warning);
+      margin: 1.25rem 0;
+    }
+
+    .timeline-divider::before,
+    .timeline-divider::after {
+      content: "";
+      flex: 1 1 auto;
+      height: 1px;
+      background: var(--panel-border);
+    }
+
+    .message {
+      display: grid;
+      grid-template-columns: 48px 1fr;
+      gap: 1.1rem;
+      margin-bottom: 1.4rem;
+    }
+
+    .message:last-of-type {
+      margin-bottom: 0;
+    }
+
+    .message .avatar {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      background: linear-gradient(135deg, #cbcccf, #e1e2e6);
+      position: relative;
+    }
+
+    .message .avatar::after {
+      content: "";
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      background: var(--presence);
+      right: -2px;
+      bottom: -2px;
+    }
+
+    .message header {
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      font-weight: 600;
+    }
+
+    .message header span {
+      color: var(--text-muted);
+      font-size: 0.82rem;
+    }
+
+    .message .bubble-card {
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow);
+      padding: 0.95rem 1.1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+
+    .message .attachments {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .attachment {
+      flex: 0 0 160px;
+      border-radius: var(--radius-sm);
+      background: linear-gradient(135deg, #f2f3f6, #ffffff);
+      border: 1px solid var(--panel-border);
+      padding: 0.75rem;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .attachment strong {
+      font-size: 0.9rem;
+    }
+
+    .attachment span {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+
+    .message .reactions {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .reaction-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      border-radius: 999px;
+      border: 1px solid var(--panel-border);
+      background: var(--panel-soft);
+      padding: 0.2rem 0.65rem;
+      font-size: 0.82rem;
+      color: var(--text-body);
+    }
+
+    .chat-composer {
+      padding: 0.65rem 0.9rem;
+      border-top: 1px solid var(--panel-border);
+      background: rgba(255, 255, 255, 0.9);
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .chat-composer .input-group {
+      border-radius: var(--radius-md);
+      border: 1px solid var(--panel-border);
+      background: var(--panel-soft);
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+
+    .chat-composer .input-group-text {
+      background: transparent;
+      border: 0;
+      color: var(--text-muted);
+    }
+
+    .chat-composer input {
+      border: 0;
+      background: transparent;
+      box-shadow: none;
+      color: var(--text-body);
+    }
+
+    .members-pane {
+      display: grid;
+      grid-template-rows: var(--chrome) 1fr;
+      background: var(--panel);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--panel-border);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      min-width: 0;
+    }
+
+    .members-pane header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0 1rem;
+      border-bottom: 1px solid var(--panel-border);
+      background: rgba(255, 255, 255, 0.85);
+    }
+
+    .members-pane .scroll {
+      overflow-y: auto;
+      padding: 1rem;
+      background: var(--panel-soft);
+    }
+
+    .roster-group {
+      margin-bottom: 1.25rem;
+    }
+
+    .roster-group:last-child {
+      margin-bottom: 0;
+    }
+
+    .roster-title {
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-size: 0.72rem;
+      color: var(--text-muted);
+      margin-bottom: 0.6rem;
+    }
+
+    .roster-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.4rem 0.5rem;
+      border-radius: var(--radius-sm);
+      transition: background 0.2s ease;
+    }
+
+    .roster-item:hover {
+      background: rgba(0, 0, 0, 0.05);
+    }
+
+    .roster-item .avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #d8d9dd, #f0f0f4);
+      position: relative;
+    }
+
+    .roster-item .avatar::after {
+      content: "";
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      background: var(--presence);
+      right: -2px;
+      bottom: -2px;
+    }
+
+    .roster-item.offline .avatar::after {
+      background: var(--text-muted);
+    }
+
+    .roster-item .meta {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+
+    .members-pane .badge {
+      background: var(--panel-soft);
+      color: var(--text-muted);
+      border: 1px solid var(--panel-border);
+      border-radius: 999px;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      padding: 0.2rem 0.75rem;
+    }
+
+    @media (max-width: 1400px) {
+      .app-grid {
+        grid-template-columns: 84px minmax(0, 1fr);
+      }
+
+      .members-pane {
+        display: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="titlebar">Discord Workspace Mock</div>
+  <main class="app-grid">
+    <aside class="server-rail">
+      <div class="home">D</div>
+      <div class="divider"></div>
+      <div class="rail-track">
+        <div class="rail-scroll">
+          <div class="server-dot round"><span class="badge">6</span></div>
+          <div class="server-dot"></div>
+          <div class="server-dot round"><span class="badge">2</span></div>
+          <div class="server-dot active"></div>
+          <div class="server-dot"></div>
+          <div class="server-dot round"><span class="badge">1</span></div>
+          <div class="server-dot"></div>
+          <div class="server-dot"></div>
+          <div class="server-dot"></div>
+          <div class="server-dot"></div>
+        </div>
+      </div>
+      <div class="rail-new">NEW</div>
+    </aside>
+
+    <section class="workspace">
+      <div class="workspace-header">
+        <div class="bubble">
+          <div class="status-dot"></div>
+          <div>
+            <div class="fw-semibold">Skyline Studio</div>
+            <div class="text-muted small">Creative &amp; branding • 4 channels</div>
+          </div>
+          <i class="bi bi-caret-down-fill ms-auto"></i>
+        </div>
+        <div class="bubble">
+          <div>
+            <div class="fw-semibold"># brand-update</div>
+            <div class="text-muted small">Sprint planning and assets</div>
+          </div>
+          <span class="pill ms-auto">General discussion</span>
+        </div>
+        <div class="header-search">
+          <label class="search-pill">
+            <i class="bi bi-search"></i>
+            <input type="search" placeholder="Search" aria-label="Search conversations">
+          </label>
+          <button class="icon-btn" aria-label="Notifications"><i class="bi bi-bell"></i></button>
+          <button class="icon-btn" aria-label="Help"><i class="bi bi-question-circle"></i></button>
+        </div>
+      </div>
+
+      <div class="main-panels">
+        <aside class="nav-pane" aria-label="Channel list">
+          <header>
+            <div class="status-dot" aria-hidden="true"></div>
+            <div>
+              <div class="fw-semibold">Skyline Studio</div>
+              <div class="text-muted small">Workspace tools</div>
+            </div>
+            <i class="bi bi-gear ms-auto"></i>
+          </header>
+          <div class="scroll">
+            <div class="category">planning</div>
+            <div class="channel active">
+              <div class="hash">#</div>
+              <div class="fw-semibold">brand-update</div>
+              <div class="meta"><i class="bi bi-pin-angle"></i> 4</div>
+            </div>
+            <div class="channel">
+              <div class="hash">#</div>
+              <div>launch-checklist</div>
+              <div class="meta"><i class="bi bi-chat-dots"></i> 9</div>
+            </div>
+            <div class="channel">
+              <div class="hash">#</div>
+              <div>team-huddle</div>
+            </div>
+
+            <div class="category mt-4">creative</div>
+            <div class="channel">
+              <div class="hash">#</div>
+              <div>design-lounge</div>
+              <div class="meta"><i class="bi bi-image"></i> 3</div>
+            </div>
+            <div class="channel">
+              <div class="hash">#</div>
+              <div>moodboard</div>
+            </div>
+          </div>
+          <footer>
+            <div class="d-flex align-items-center gap-2">
+              <div class="status-dot" style="width:32px;height:32px;" aria-hidden="true"></div>
+              <div>
+                <div class="fw-semibold">mmn345</div>
+                <div class="text-muted small">Creative Lead</div>
+              </div>
+            </div>
+            <div class="d-flex align-items-center gap-3 text-muted">
+              <i class="bi bi-mic"></i>
+              <i class="bi bi-headphones"></i>
+              <i class="bi bi-gear"></i>
+            </div>
+          </footer>
+        </aside>
+
+        <section class="chat-pane" aria-label="Channel conversation">
+          <div class="chat-header">
+            <div class="fw-semibold"># brand-update</div>
+            <span class="tag">Sprint • Week 5</span>
+          </div>
+          <div class="chat-scroll">
+            <div class="timeline-divider">New</div>
+
+            <article class="message" aria-label="Message from Alex Carter at 9:41 AM">
+              <div class="avatar" aria-hidden="true"></div>
+              <div>
+                <header>Alex Carter <span>9:41 AM</span></header>
+                <div class="bubble-card">
+                  <p class="mb-0">Morning team! Uploading the revised product hero along with the breakdown doc. Feedback welcome before noon.</p>
+                  <div class="attachments">
+                    <div class="attachment">
+                      <strong>hero-layout.psd</strong>
+                      <span>24.1 MB • layered source</span>
+                    </div>
+                    <div class="attachment">
+                      <strong>launch-notes.pdf</strong>
+                      <span>Strategy overview • 3 pages</span>
+                    </div>
+                  </div>
+                  <div class="reactions">
+                    <span class="reaction-pill">👍 12</span>
+                    <span class="reaction-pill">🔥 6</span>
+                    <span class="reaction-pill">💡 3</span>
+                  </div>
+                </div>
+              </div>
+            </article>
+
+            <article class="message" aria-label="Message from Priya Singh at 9:52 AM">
+              <div class="avatar" aria-hidden="true"></div>
+              <div>
+                <header>Priya Singh <span>9:52 AM</span></header>
+                <div class="bubble-card">
+                  <p class="mb-0">Mockups look solid! I tweaked the typography spacing and dropped alternate exports in the drive. Take a peek 👇</p>
+                  <div class="attachments">
+                    <div class="attachment">
+                      <strong>campaign_variations.zip</strong>
+                      <span>8 files • 46.7 MB</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </article>
+
+            <article class="message" aria-label="Message from Jordan Lee at 10:08 AM">
+              <div class="avatar" aria-hidden="true"></div>
+              <div>
+                <header>Jordan Lee <span>10:08 AM</span></header>
+                <div class="bubble-card">
+                  <p class="mb-2">Ran through QA and added comments for sections 2 and 4. Tagging @Alex for the animation handoff.</p>
+                  <div class="reactions">
+                    <span class="reaction-pill">✅ 4</span>
+                    <span class="reaction-pill">🙌 7</span>
+                  </div>
+                </div>
+              </div>
+            </article>
+          </div>
+          <div class="chat-composer">
+            <div class="input-group">
+              <span class="input-group-text"><i class="bi bi-plus-lg"></i></span>
+              <input type="text" class="form-control" placeholder="Message #brand-update" aria-label="Message input">
+              <span class="input-group-text"><i class="bi bi-emoji-smile"></i></span>
+              <span class="input-group-text"><i class="bi bi-paperclip"></i></span>
+              <span class="input-group-text"><i class="bi bi-send-fill"></i></span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </section>
+
+    <aside class="members-pane" aria-label="Member list">
+      <header>
+        <div class="fw-semibold">Members</div>
+        <span class="badge ms-auto">512 Online</span>
+      </header>
+      <div class="scroll">
+        <div class="roster-group">
+          <div class="roster-title">Admins • 2</div>
+          <div class="roster-item">
+            <div class="avatar" aria-hidden="true"></div>
+            <div>
+              <div class="fw-semibold">Username</div>
+              <div class="meta">Reviewing sprint board</div>
+            </div>
+          </div>
+          <div class="roster-item">
+            <div class="avatar" aria-hidden="true"></div>
+            <div>
+              <div class="fw-semibold">Username</div>
+              <div class="meta">Playing: Fortnite</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="roster-group">
+          <div class="roster-title">Design • 4</div>
+          <div class="roster-item">
+            <div class="avatar" aria-hidden="true"></div>
+            <div>
+              <div class="fw-semibold">Username</div>
+              <div class="meta">Working on hero layout</div>
+            </div>
+          </div>
+          <div class="roster-item">
+            <div class="avatar" aria-hidden="true"></div>
+            <div>
+              <div class="fw-semibold">Username</div>
+              <div class="meta">Prototyping interactions</div>
+            </div>
+          </div>
+          <div class="roster-item offline">
+            <div class="avatar" aria-hidden="true"></div>
+            <div>
+              <div class="fw-semibold">Username</div>
+              <div class="meta">Last seen 2h ago</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </aside>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- retheme the mock with updated palette, radii, and shadows to better align with the provided light reference
- rebuild the server rail, header bubbles, channel list, chat timeline, and roster markup to mirror the screenshot composition

## Testing
- not run (static HTML)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d518e55948324bf2fa8774402fabe)